### PR TITLE
fix: move syntect to dev dependencies

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 seed = "0.9.2"
 futures = "0.3"
 async-trait = "0.1.73"
+
+[dev-dependencies]
 syntect = "5.1.0"
 
 [dependencies.common]


### PR DESCRIPTION
it does not build on wasm targets because of c code, see https://github.com/rust-onig/rust-onig/issues/153